### PR TITLE
bugfix: update green color to a darker shade

### DIFF
--- a/src/components/Explanation.jsx
+++ b/src/components/Explanation.jsx
@@ -21,13 +21,13 @@ function Explanation() {
           Datasource:{" "}
           <a
             href="https://api.carbonintensity.org.uk"
-            className="text-green-500"
+            className="text-green-700"
           >
             Official Carbon Intensity API for Great Britain
           </a>{" "}
           developed by <em>National Energy System Operator</em> (<em>NESO</em>).
           You can find out more about carbon intensity at{" "}
-          <a href="https://carbonintensity.org.uk" className="text-green-500">
+          <a href="https://carbonintensity.org.uk" className="text-green-700">
             carbonintensity.org.uk
           </a>
         </p>
@@ -35,7 +35,7 @@ function Explanation() {
           Data license:{" "}
           <a
             href="https://creativecommons.org/licenses/by/4.0/"
-            className="text-green-500"
+            className="text-green-700"
           >
             CC-BY-4.0
           </a>

--- a/src/components/Heading.jsx
+++ b/src/components/Heading.jsx
@@ -9,7 +9,7 @@ function Heading() {
         className="w-16 h-16 sm:w-24 sm:h-24 md:w-28 md:h-28 lg:w-32 lg:h-32 xl:w-40 xl:h-40"
       />
       <h1 className="p-0 m-4 text-2xl sm:text-4xl lg:text-6xl xl:text-7xl">
-        How <span className="text-green-500">Green</span> Is Your Clean?
+        How <span className="text-green-700">Green</span> Is Your Clean?
       </h1>
     </header>
   );


### PR DESCRIPTION
Change the text color from green-500 to green-700 in the Heading and Explanation components. This enhances the visual contrast