### PR TITLE
bugfix: add target="_blank" to external links

### DIFF
--- a/src/components/Explanation.jsx
+++ b/src/components/Explanation.jsx
@@ -21,13 +21,18 @@ function Explanation() {
           Datasource:{" "}
           <a
             href="https://api.carbonintensity.org.uk"
+            target="_blank"
             className="text-green-700"
           >
             Official Carbon Intensity API for Great Britain
           </a>{" "}
           developed by <em>National Energy System Operator</em> (<em>NESO</em>).
           You can find out more about carbon intensity at{" "}
-          <a href="https://carbonintensity.org.uk" className="text-green-700">
+          <a
+            href="https://carbonintensity.org.uk"
+            target="_blank"
+            className="text-green-700"
+          >
             carbonintensity.org.uk
           </a>
         </p>
@@ -35,6 +40,7 @@ function Explanation() {
           Data license:{" "}
           <a
             href="https://creativecommons.org/licenses/by/4.0/"
+            target="_blank"
             className="text-green-700"
           >
             CC-BY-4.0


### PR DESCRIPTION
Add target="_blank" attribute to external links to ensure they open in a new tab.